### PR TITLE
Improve logging with regard to 'msg_id' and exception

### DIFF
--- a/paf/logging.py
+++ b/paf/logging.py
@@ -41,16 +41,16 @@ def _extra(category):
 
 
 def debug(msg, category):
-    logger.debug(msg, _extra(category))
+    logger.debug(msg, extra=_extra(category))
 
 
 def info(msg, category):
-    logger.info(msg, _extra(category))
+    logger.info(msg, extra=_extra(category))
 
 
 def warning(msg, category):
-    logger.warning(msg, _extra(category))
+    logger.warning(msg, extra=_extra(category))
 
 
 def exception(msg):
-    logger.exception(_extra(LogCategory.INTERNAL))
+    logger.exception(msg, extra=_extra(LogCategory.INTERNAL))


### PR DESCRIPTION
'msg_id' now is part of parameter 'extra' to the logging functions,
which aligns with RFC5424.

'msg" to exception function is no longer ignored.

Signed-off-by: Xin Ren <nathanrenxin@gmail.com>