### PR TITLE
Fix errors reported by flake8

### DIFF
--- a/paf/client.py
+++ b/paf/client.py
@@ -86,7 +86,7 @@ class Transaction:
         if ta_cmd != self.ta_type.cmd:
             raise ProtocolError("Received message in transaction %d; expected "
                                 "\"%s\" command, but got \"%s\"." %
-                                (self.ta_type.cmd, ta_cmd))
+                                (self.ta_id, self.ta_type.cmd, ta_cmd))
 
         msg_type = proto.FIELD_MSG_TYPE.pull(in_msg)
 

--- a/test/test_paf.py
+++ b/test/test_paf.py
@@ -1086,8 +1086,8 @@ def test_unsubscribe_from_non_owner(server):
     delayed_close(conn1)
 
 
-def by_id(l):
-    return l[0]
+def by_id(keys):
+    return keys[0]
 
 
 NUM_CLIENTS = 10


### PR DESCRIPTION
Added missing substitution in function
consume_message in paf/client.py according
to flake8 rule F507;

Changed argument name for function by_id in
test/test_paf.py from 'l' to 'keys' according
to flake8 rule E741.

The code now is compatible with flake8-3.9.1.

Signed-off-by: Xin Ren <nathan.ren@ericsson.com>